### PR TITLE
remove $-prefix that can break legacy code on same site

### DIFF
--- a/src/core/resize.js
+++ b/src/core/resize.js
@@ -31,7 +31,7 @@ export default {
 
     },
     methods: {
-        $_change_video_resolution() {
+        _change_video_resolution() {
             this.width = this.$_innerWidth();
         },
         $_innerWidth() {
@@ -44,12 +44,12 @@ export default {
 
     },
     beforeMount() {
-        this.$_change_video_resolution();
+        this._change_video_resolution();
     },
     mounted() {
-        window.addEventListener('resize', throttle(this.$_change_video_resolution, 250));
+        window.addEventListener('resize', throttle(this._change_video_resolution, 250));
     },
     beforeUnmount() {
-        window.removeEventListener('resize', throttle(this.$_change_video_resolution, 250));
+        window.removeEventListener('resize', throttle(this._change_video_resolution, 250));
     },
 };

--- a/src/core/resize.js
+++ b/src/core/resize.js
@@ -1,5 +1,6 @@
 import throttle from '../lib/throttle';
 
+/* eslint-disable no-underscore-dangle */
 export default {
     data() {
         return {
@@ -53,3 +54,4 @@ export default {
         window.removeEventListener('resize', throttle(this._change_video_resolution, 250));
     },
 };
+/* eslint-enable no-underscore-dangle */


### PR DESCRIPTION
I'm adding new features to a site that has other parts built with jquery. Everything was playing nice so far, but installing this module breaks other parts of the site. This seems to fix the issue. It could happen to others, so maybe removing the $-prefix would be good idea.